### PR TITLE
min function 

### DIFF
--- a/graph-parser_c/src/biconnected.c
+++ b/graph-parser_c/src/biconnected.c
@@ -26,7 +26,7 @@ void DFS_visit(struct node_graph * u,struct list *s,int * d,int * low,
  * @param b An integer
  * @return the minimum value of @a and @b. 
  */
-inline int min(int a, int b){
+static inline int min(int a, int b){
     if(a<b)
         return a;
     return b;


### PR DESCRIPTION
My laptop and the Openwrt toolchain can't compile the library showing this error:
`cc -std=gnu11 -g -fPIC -D_GNU_SOURCE -o ../build/prince_c prince.o lib/ini.o parser.o -L../../graph-parser_c/build/lib -lgraphcparser -ldl -ljson-c -lm
../../graph-parser_c/build/lib/libgraphcparser.so: riferimento non definito a "min"
collect2: error: ld returned 1 exit status
Makefile:20: set di istruzioni per l'obiettivo "prince_c" non riuscito
make[1]: *** [prince_c] Errore 1`

I've managed to make it work by adding the "static" keyword in the function definition